### PR TITLE
Adds support for query parameters in URL templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The metadata of the root container defines 4 different derived resources:
 - `http://localhost:3000/test`: A basic derived resource applying a query to a single selector.
 - `http://localhost:3000/template/{var}`: A template for derived resources where `var` will be applied to the query.
      You can try out http://localhost:3000/template/foaf:knows and http://localhost:3000/template/foaf:name.
+- `http://localhost:3000/query`: Similar to the previous example, but instead uses a query parameter for the variable.
+     For example, `http://localhost:3000/query?var=foaf:knows`.
 - `http://localhost:3000/pattern`: A derived resource whose selectors are all resources in a container.
 - `http://localhost:3000/multiple`: A derived resource with multiple selectors.
 

--- a/config/derived.json
+++ b/config/derived.json
@@ -44,6 +44,19 @@
         "@type": "PatchingStore",
         "source": { "@id": "urn:solid-server:derived:RepresentationConvertingStore" }
       }
+    },
+    {
+      "comment": [
+        "Keep query parameters in identifiers.",
+        "This makes it so that any query parameters can cause issues with normal resources so we might want a more robust solution."
+      ],
+      "@id": "urn:solid-server:derived:TargetExtractorOverride",
+      "@type": "Override",
+      "overrideInstance": { "@id": "urn:solid-server:default:TargetExtractor" },
+      "overrideParameters": {
+        "@type": "OriginalUrlExtractor",
+        "includeQueryString": true
+      }
     }
   ]
 }

--- a/src/SparqlFilterHandler.ts
+++ b/src/SparqlFilterHandler.ts
@@ -48,6 +48,7 @@ export class SparqlFilterHandler extends FilterHandler {
 
     const engine = new QueryEngine();
     try {
+      console.log(query);
       const result = await engine.queryQuads(query, { sources: [data] });
       return guardStream(Readable.from(this.convertAsyncIterator(result)));
     } catch(error: unknown) {

--- a/src/SparqlFilterHandler.ts
+++ b/src/SparqlFilterHandler.ts
@@ -48,7 +48,6 @@ export class SparqlFilterHandler extends FilterHandler {
 
     const engine = new QueryEngine();
     try {
-      console.log(query);
       const result = await engine.queryQuads(query, { sources: [data] });
       return guardStream(Readable.from(this.convertAsyncIterator(result)));
     } catch(error: unknown) {

--- a/templates/root/base/.meta
+++ b/templates/root/base/.meta
@@ -16,6 +16,13 @@
 
 <>
     derived:derivedResource [
+        derived:template "query{?var}";
+        derived:selector </data>;
+        derived:filter </filter-var>
+    ].
+
+<>
+    derived:derivedResource [
         derived:template "pattern";
         derived:selector </container/*>;
         derived:filter </filter>


### PR DESCRIPTION
Changes a flag in the `OriginalUrlExtractor` so query parameters no longer get removed. This way these can be used for URL templates.

The disadvantage is that if someone adds a parameter to the identifier of a normal resource, the server will now interpret that as a different resource, which can cause all kinds of issues. So we want something more robust if this stays.