### PR TITLE
Add caching on multiple levels

### DIFF
--- a/config/derived-auth.json
+++ b/config/derived-auth.json
@@ -4,6 +4,7 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@solidlab/derived-resources-component/^1.0.0/components/context.jsonld"
   ],
   "import": [
+    "derived:config/parts/cache.json",
     "derived:config/parts/disable-index.json",
     "derived:config/parts/filter.json",
     "derived:config/parts/manager.json",

--- a/config/derived.json
+++ b/config/derived.json
@@ -4,6 +4,7 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@solidlab/derived-resources-component/^1.0.0/components/context.jsonld"
   ],
   "import": [
+    "derived:config/parts/cache.json",
     "derived:config/parts/disable-index.json",
     "derived:config/parts/filter.json",
     "derived:config/parts/manager.json",

--- a/config/parts/cache.json
+++ b/config/parts/cache.json
@@ -1,0 +1,23 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@solidlab/derived-resources-component/^1.0.0/components/context.jsonld"
+  ],
+  "@graph": [
+    {
+      "comment": "Insert the cache right before the DataAccessorBasedStore.",
+      "@id": "urn:solid-server:derived:CacheStoreOverride",
+      "@type": "Override",
+      "overrideInstance": { "@id": "urn:solid-server:default:ResourceStore_Converting" },
+      "overrideParameters": {
+        "@type": "RepresentationConvertingStore",
+        "source": {
+          "@id": "urn:solid-server:derived:CachedResourceStore",
+          "@type": "CachedResourceStore",
+          "source": { "@id": "urn:solid-server:default:ResourceStore_Backend" },
+          "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" }
+        }
+      }
+    }
+  ]
+}

--- a/config/parts/filter.json
+++ b/config/parts/filter.json
@@ -17,17 +17,28 @@
         "@id": "urn:solid-server:default:FilterExecutor",
         "@type": "MappingFilterExecutor",
         "source": {
-          "@id": "urn:solid-server:default:FilterExecutorHandler",
-          "@type": "WaterfallHandler",
-          "handlers": [
-            {
-              "@type": "IndexFilterExecutor"
-            },
-            {
-              "@type": "RdfFilterExecutor",
-              "source": { "@type": "SparqlFilterExecutor" }
-            }
-          ]
+          "@id": "urn:solid-server:default:CachedFilterExecutor",
+          "@type": "CachedFilterExecutor",
+          "source": {
+            "@id": "urn:solid-server:default:FilterExecutorHandler",
+            "@type": "WaterfallHandler",
+            "handlers": [
+              {
+                "@id": "urn:solid-server:default:IndexFilterExecutor",
+                "@type": "IndexFilterExecutor",
+                "resourceIndexParser": {
+                  "@id": "urn:solid-server:default:CachedResourceIndexParser",
+                  "@type": "CachedQuadFilterParser",
+                  "source": { "@type": "BaseQuadFilterParser" }
+                }
+              },
+              {
+                "@id": "urn:solid-server:default:RdfFilterExecutor",
+                "@type": "RdfFilterExecutor",
+                "source": { "@type": "SparqlFilterExecutor" }
+              }
+            ]
+          }
         }
       }
     }

--- a/derived-index.md
+++ b/derived-index.md
@@ -92,6 +92,18 @@ The previous example would only show the examples everyone has read access to.
 If you perform the GET request and add the header `Authorization: WebID http://example.com/alice`,
 you will see more results.
 
+## Caching
+
+Besides the caching already present for all derived resources,
+there is also some specific caching for derived index resources.
+For every resource that is used to generate an index,
+the server caches the matching quads that resource had for the filter.
+This way, if new resources get included in the index generation,
+due to using different credentials for example,
+the results of the ones previously included can be reused.
+Similar to standard caching for derived resources,
+the timestamp of the resource is used to make sure outdated data is not used.
+
 ## CSS architecture workarounds
 
 While it was possible to implement these new features without having to make any changes to the CSS,
@@ -128,8 +140,3 @@ To prevent this,
 some of the dependencies are applied after initialization.
 The `ParamSetter` interface and `ParamInitializer` class have been created specifically for this purpose.
 An example of this issue can be seen in the `AuthorizedSelectorParser`.
-
-## Known issues
-
-The same issues as the original derived resources apply here.
-The lack of caching might be more impactful here as generally there will be more input resources.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "derived-resources-component",
+  "name": "@solidlab/derived-resources-component",
   "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "derived-resources-component",
+      "name": "@solidlab/derived-resources-component",
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
@@ -13,7 +13,9 @@
         "@rdfjs/types": "^1.1.0",
         "@solid/community-server": "^7.0.3",
         "asynciterator": "^3.8.1",
+        "lru-cache": "^10.2.0",
         "n3": "^1.17.2",
+        "rdf-string": "^1.6.3",
         "uri-template-lite": "^23.4.0"
       },
       "devDependencies": {
@@ -7049,9 +7051,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "engines": {
         "node": "14 || >=16.14"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "@rdfjs/types": "^1.1.0",
     "@solid/community-server": "^7.0.3",
     "asynciterator": "^3.8.1",
+    "lru-cache": "^10.2.0",
     "n3": "^1.17.2",
+    "rdf-string": "^1.6.3",
     "uri-template-lite": "^23.4.0"
   },
   "devDependencies": {

--- a/src/CachedResourceStore.ts
+++ b/src/CachedResourceStore.ts
@@ -1,0 +1,166 @@
+import {
+  AuxiliaryIdentifierStrategy,
+  ChangeMap,
+  Conditions,
+  createErrorMessage,
+  getLoggerFor,
+  PassthroughStore,
+  Patch,
+  Representation,
+  RepresentationPreferences,
+  ResourceIdentifier,
+  ResourceStore,
+  SingleThreaded
+} from '@solid/community-server';
+import { LRUCache } from 'lru-cache';
+import {
+  CachedRepresentation,
+  cachedToRepresentation,
+  calculateCachedRepresentationSize,
+  duplicateRepresentation,
+  representationToCached
+} from './util/CacheUtil';
+
+export interface CachedResourceStoreArgs {
+  source: ResourceStore;
+  metadataStrategy: AuxiliaryIdentifierStrategy;
+  cacheSettings?: { max?: number, maxSize?: number };
+}
+/**
+ * A {@link ResourceStore} that caches representation responses.
+ * Caching is done using the identifier as key, so this should be at the end of the store chain.
+ * after content negotiation, as that results in different representations for the same identifier.
+ *
+ * Cache entries are invalidated after any successful write operation.
+ * Because of this, this store does not work with worker threads,
+ * as the thread invalidating the cache might not be the one that has that cache entry.
+ *
+ * Cache settings can be set to determine the max cache entries, or the max size for the entire cache (in bytes).
+ * `maxSize` only works for binary data streams.
+ */
+export class CachedResourceStore extends PassthroughStore implements SingleThreaded {
+  protected readonly logger = getLoggerFor(this);
+
+  protected readonly metadataStrategy: AuxiliaryIdentifierStrategy;
+  protected readonly cache: LRUCache<string, CachedRepresentation>;
+
+  // Allows canceling caching if the resource was invalidated before caching was finished
+  protected readonly cacheProgress: Record<string, { identifier: ResourceIdentifier, representation: Representation }> = {};
+
+  public constructor(args: CachedResourceStoreArgs) {
+    super(args.source);
+    this.metadataStrategy = args.metadataStrategy;
+    const max = args.cacheSettings?.max ?? 1000;
+    const maxSize = args.cacheSettings?.maxSize ?? 100_000_000; // 100 MB
+
+    this.cache = new LRUCache({ max, maxSize, sizeCalculation: calculateCachedRepresentationSize });
+  }
+
+  public async hasResource(identifier: ResourceIdentifier): Promise<boolean> {
+    if (this.cache.has(identifier.path) || this.cacheProgress[identifier.path]) {
+      return true;
+    }
+    return super.hasResource(identifier);
+  }
+
+  public async getRepresentation(identifier: ResourceIdentifier, preferences: RepresentationPreferences, conditions?: Conditions): Promise<Representation> {
+    this.logger.debug(`Checking cache with key ${identifier.path}`);
+
+    const cached = this.cache.get(identifier.path);
+    if (cached) {
+      this.logger.debug(`Cache hit with key ${identifier.path}`);
+      return cachedToRepresentation(cached);
+    }
+    const representation = await super.getRepresentation(identifier, preferences, conditions);
+    return this.cacheRepresentation(identifier, representation);
+  }
+
+  public async addResource(container: ResourceIdentifier, representation: Representation, conditions?: Conditions): Promise<ChangeMap> {
+    const changes = await super.addResource(container, representation, conditions);
+    this.invalidateCache(changes);
+    return changes;
+  }
+
+  public async setRepresentation(identifier: ResourceIdentifier, representation: Representation, conditions?: Conditions): Promise<ChangeMap> {
+    const changes = await super.setRepresentation(identifier, representation, conditions);
+    this.invalidateCache(changes);
+    return changes;
+  }
+
+  public async modifyResource(identifier: ResourceIdentifier, patch: Patch, conditions?: Conditions): Promise<ChangeMap> {
+    const changes = await super.modifyResource(identifier, patch, conditions);
+    this.invalidateCache(changes);
+    return changes;
+  }
+
+  public async deleteResource(identifier: ResourceIdentifier, conditions?: Conditions): Promise<ChangeMap> {
+    const changes = await super.deleteResource(identifier, conditions);
+    this.invalidateCache(changes);
+    return changes;
+  }
+
+  /**
+   * Cache the given representation for the given identifier.
+   * Returns a representation that can be used instead of the one given as input,
+   * as that one will be read during the caching.
+   * Caching will be done async, to prevent blocking the result while caching is in progress.
+   * If caching is already in progress for the identifier,
+   * no new caching process will be started.
+   */
+  protected cacheRepresentation(identifier: ResourceIdentifier, representation: Representation): Representation {
+    if (this.cacheProgress[identifier.path]) {
+      return representation;
+    }
+
+    const [ copy1, copy2 ] = duplicateRepresentation(representation);
+
+    this.cacheProgress[identifier.path] = { identifier, representation: copy1 };
+
+    // Don't await so caching doesn't block returning a result
+    representationToCached(copy1)
+      .then((newCached) => {
+        // Progress entry being removed implies that the result was invalidated in the meantime
+        if (this.cacheProgress[identifier.path]?.identifier === identifier) {
+          this.cache.set(identifier.path, newCached);
+          delete this.cacheProgress[identifier.path];
+        }
+      })
+      .catch((err) => {
+        // This just means the request was not interested in the data and closed the stream
+        if (err.message !== 'Premature close') {
+          this.logger.error(`Unable to cache representation for ${identifier.path}: ${createErrorMessage(err)}`);
+        }
+      });
+
+    return copy2;
+  }
+
+  /**
+   * Invalidates the cache for all identifiers in the {@link ChangeMap}.
+   * Also invalidates the corresponding metadata resource,
+   * or the corresponding subject resource in the case the identifier is a metadata resource,
+   * since the CSS backend does not return those in the response (yet).
+   */
+  protected invalidateCache(changeMap: ChangeMap): void {
+    for (const identifier of changeMap.keys()) {
+      this.invalidateIdentifier(identifier);
+      if (this.metadataStrategy.isAuxiliaryIdentifier(identifier)) {
+        this.invalidateIdentifier(this.metadataStrategy.getSubjectIdentifier(identifier));
+      } else {
+        this.invalidateIdentifier(this.metadataStrategy.getAuxiliaryIdentifier(identifier));
+      }
+    }
+  }
+
+  /**
+   * Invalidate caching of the given identifier.
+   * This will also terminate any incomplete caching for that identifier.
+   */
+  protected invalidateIdentifier(identifier: ResourceIdentifier): void {
+    this.cache.delete(identifier.path);
+    if (this.cacheProgress[identifier.path]) {
+      this.cacheProgress[identifier.path].representation.data.destroy();
+      delete this.cacheProgress[identifier.path];
+    }
+  }
+}

--- a/src/filter/CachedFilterExecutor.ts
+++ b/src/filter/CachedFilterExecutor.ts
@@ -1,0 +1,101 @@
+import { createErrorMessage, DC, getLoggerFor, Representation } from '@solid/community-server';
+import { LRUCache } from 'lru-cache';
+import { createHash } from 'node:crypto';
+import {
+  CachedRepresentation,
+  cachedToRepresentation,
+  calculateCachedRepresentationSize,
+  duplicateRepresentation,
+  representationToCached
+} from '../util/CacheUtil';
+import { FilterExecutor, FilterExecutorInput } from './FilterExecutor';
+
+interface ChecksumCachedRepresentation extends CachedRepresentation {
+  checksum: string;
+}
+
+/**
+ * A {@link FilterExecutor} that caches the result for faster reuse.
+ * For each cache entry, a checksum is generated based on the filter,
+ * all resource identifiers, and their corresponding timestamps.
+ * If the checksum of the cached entry no longer matches, it will be replaced with the current version.
+ *
+ * Cache settings can be set to determine the max cache entries, or the max size for the entire cache (in bytes).
+ */
+export class CachedFilterExecutor extends FilterExecutor {
+  protected readonly logger = getLoggerFor(this);
+
+  protected readonly source: FilterExecutor;
+  protected readonly cache: LRUCache<string, ChecksumCachedRepresentation>;
+
+  public constructor(source: FilterExecutor, cacheSettings?: { max?: number; maxSize?: number }) {
+    super();
+    this.source = source;
+    const max = cacheSettings?.max ?? 1000;
+    const maxSize = cacheSettings?.maxSize ?? 100_000_000; // 100 MB
+
+    this.cache = new LRUCache({ max, maxSize, sizeCalculation: calculateCachedRepresentationSize });
+  }
+
+  public async canHandle(input: FilterExecutorInput): Promise<void> {
+    return this.source.canHandle(input);
+  }
+
+  public async handle(input: FilterExecutorInput): Promise<Representation> {
+    const key = input.config.identifier.path;
+    const checksum = this.getChecksum(input);
+    this.logger.debug(`Checking cache with key ${key} and ${checksum}`);
+    // No checksum means the filter format did not allow one to be generated, so we don't attempt caching
+    if (!checksum) {
+      return this.source.handle(input);
+    }
+
+    const cached = this.cache.get(key);
+    if (cached?.checksum === checksum) {
+      this.logger.debug(`Cache hit with key ${key} and checksum ${checksum}`);
+      return cachedToRepresentation(cached);
+    }
+
+    const representation = await this.source.handle(input);
+    return this.cacheRepresentation(key, checksum, representation);
+  }
+
+  /**
+   * Cache the given representation with the given key/checksum.
+   * Returns a representation that can be used instead of the one given as input,
+   * as that one will be read during the caching.
+   * Caching will be done async, to prevent blocking the result while caching is in progress.
+   */
+  protected cacheRepresentation(key: string, checksum: string, representation: Representation): Representation {
+    const [ copy1, copy2 ] = duplicateRepresentation(representation);
+    // Don't await so the result can immediately be returned while caching
+    representationToCached(copy1)
+      .then((newCached) => this.cache.set(key, { ...newCached, checksum }))
+      .catch((err) => {
+        // This just means the request was not interested in the data and closed the stream
+        if (err.message !== 'Premature close') {
+          this.logger.error(`Unable to cache derived representation for ${key}: ${createErrorMessage(err)}`);
+        }
+      });
+    return copy2;
+  }
+
+  /**
+   * Generates a checksum based on the filter/resources/timestamps,
+   * ensuring this value changes if anything impacting the derived resource changes.
+   */
+  protected getChecksum(input: FilterExecutorInput): string | undefined {
+    if (typeof input.filter.data !== 'string') {
+      return;
+    }
+
+    const resourceKeys = input.representations.map((representation): string => {
+      const id = representation.metadata.identifier.value;
+      const timestamp = representation.metadata.get(DC.terms.modified)?.value;
+      return `${id}:${timestamp}`;
+    });
+    resourceKeys.sort();
+
+    return createHash('md5').update(`${input.filter.data} ${resourceKeys.join(' ')}`).digest('hex');
+  }
+}

--- a/src/filter/idx/BaseQuadFilterParser.ts
+++ b/src/filter/idx/BaseQuadFilterParser.ts
@@ -1,0 +1,37 @@
+import { Quad } from '@rdfjs/types';
+import { Guarded, transformSafely } from '@solid/community-server';
+import { Readable } from 'node:stream';
+import { QuadFilterParser, QuadFilterParserArgs } from './QuadFilterParser';
+
+/**
+ * A {@link QuadFilterParser} that removes all triples from a representation data stream
+ * that do not match a given quad template.
+ */
+export class BaseQuadFilterParser extends QuadFilterParser {
+  public async handle({ filter, representation }: QuadFilterParserArgs): Promise<Guarded<Readable>> {
+    const matchFn = (quad: Quad): Quad | undefined => {
+      let match: Quad | undefined;
+      for (const pos of [ 'subject', 'predicate', 'object', 'graph' ] as const) {
+        if (filter[pos]) {
+          if (filter[pos]?.termType === 'Variable') {
+            match = quad;
+          } else if (!quad[pos].equals(filter[pos])) {
+            return;
+          }
+        }
+      }
+      return match;
+    }
+
+    const transform = transformSafely(representation.data, {
+      transform: (data: Quad) => {
+        const match = matchFn(data);
+        if (match) {
+          transform.push(match);
+        }
+      },
+      objectMode: true,
+    });
+    return transform;
+  }
+}

--- a/src/filter/idx/CachedQuadFilterParser.ts
+++ b/src/filter/idx/CachedQuadFilterParser.ts
@@ -1,0 +1,99 @@
+import { Quad } from '@rdfjs/types';
+import { DC, getLoggerFor, Guarded, guardedStreamFrom, InternalServerError, pipeSafely } from '@solid/community-server';
+import { LRUCache } from 'lru-cache';
+import { PassThrough, Readable } from 'node:stream';
+import { termToString } from 'rdf-string';
+import { QuadFilterParser, QuadFilterParserArgs } from './QuadFilterParser';
+
+interface CachedQuads {
+  quads: Quad[];
+  checksum: string;
+}
+
+/**
+ * A {@link QuadFilterParser} that caches results.
+ * The identifier, the last time the resource was modified and the filter are combined to generate a checksum.
+ * If the checksum of the cached entry no longer matches, it will be replaced with the current version
+ *
+ * Cache settings can be set to determine the max cache entries, or the max size for the entire cache (in bytes).
+ */
+export class CachedQuadFilterParser extends QuadFilterParser {
+  protected readonly logger = getLoggerFor(this);
+
+  protected readonly source: QuadFilterParser;
+  protected readonly cache: LRUCache<string, CachedQuads>;
+
+  public constructor(source: QuadFilterParser, cacheSettings?: { max?: number, maxSize?: number }) {
+    super();
+    this.source = source;
+    const max = cacheSettings?.max ?? 1000;
+    const maxSize = cacheSettings?.maxSize ?? 100_000_000; // 100MB
+    const sizeCalculation: LRUCache.SizeCalculator<string, CachedQuads> = ({ quads }): number => {
+      let size = 1;
+      for (const quad of quads) {
+        size += quad.subject.value.length;
+        size += quad.predicate.value.length;
+        size += quad.object.value.length;
+        size += quad.graph.value.length;
+      }
+      return size;
+    };
+    this.cache = new LRUCache({ max, maxSize, sizeCalculation });
+  }
+
+  public async canHandle(input: QuadFilterParserArgs): Promise<void> {
+    return this.source.canHandle(input);
+  }
+
+  public async handle(input: QuadFilterParserArgs): Promise<Guarded<Readable>> {
+    const key = this.getKey(input);
+    const checksum = this.getChecksum(input);
+    this.logger.debug(`Checking cache with key ${key} and checksum ${checksum}`);
+
+    const cached = this.cache.get(key);
+    if (cached && cached.checksum === checksum) {
+      this.logger.debug(`Cache hit with key ${key} and checksum ${checksum}`);
+      return guardedStreamFrom(cached.quads, { objectMode: true });
+    }
+
+    const result = await this.source.handle(input);
+    // Pipe the stream twice, so we have 2 copies, one for the cache and one to return
+    this.cacheResult(key, checksum, pipeSafely(result, new PassThrough({ objectMode: true })));
+    return pipeSafely(result, new PassThrough({ objectMode: true }));
+  }
+
+  /**
+   * Generates the key based on the identifier/filter.
+   */
+  protected getKey(input: QuadFilterParserArgs): string {
+    const subject = termToString(input.filter.subject);
+    const predicate = termToString(input.filter.predicate);
+    const object = termToString(input.filter.object);
+    const graph = termToString(input.filter.graph);
+    return `${input.representation.metadata.identifier.value} ${subject} ${predicate} ${object} ${graph}`;
+  }
+
+  /**
+   * Generates the checksum based on the timestamp.
+   */
+  protected getChecksum(input: QuadFilterParserArgs): string {
+    const timestamp = input.representation.metadata.get(DC.terms.modified)?.value;
+    if (!timestamp) {
+      throw new InternalServerError('Index caching is only possible for backends that return a last modified timestamp.');
+    }
+    return timestamp;
+  }
+
+  /**
+   * Reads the data stream to add it to the cache with the given key.
+   */
+  protected cacheResult(key: string, checksum: string, data: Readable): void {
+    const quads: Quad[] = [];
+    data.on('data', (quad): void => {
+      quads.push(quad);
+    });
+    data.on('end', () => {
+      this.cache.set(key, { checksum, quads });
+    });
+  }
+}

--- a/src/filter/idx/QuadFilterParser.ts
+++ b/src/filter/idx/QuadFilterParser.ts
@@ -1,0 +1,13 @@
+import { Quad } from '@rdfjs/types';
+import { AsyncHandler, Guarded, Representation } from '@solid/community-server';
+import { Readable } from 'node:stream';
+
+export interface QuadFilterParserArgs {
+  filter: Partial<Quad>;
+  representation: Representation;
+}
+
+/**
+ * Applies a quad filter to a given representation to return a quad stream of all triples matching the filter.
+ */
+export abstract class QuadFilterParser extends AsyncHandler<QuadFilterParserArgs, Guarded<Readable>> {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,18 @@ export * from './credentials/CredentialsStorage';
 export * from './credentials/StoreCredentialsAuthorizer';
 export * from './credentials/WeakStorage';
 
+export * from './filter/idx/BaseQuadFilterParser';
+export * from './filter/idx/CachedQuadFilterParser';
+export * from './filter/idx/IndexFilterExecutor';
+export * from './filter/idx/QuadFilterParser';
+
 export * from './filter/BaseFilterHandler';
+export * from './filter/CachedFilterExecutor';
 export * from './filter/RdfFilterExecutor';
 export * from './filter/Filter';
 export * from './filter/FilterExecutor';
 export * from './filter/FilterHandler';
 export * from './filter/FilterParser';
-export * from './filter/IndexFilterExecutor';
 export * from './filter/MappingFilterExecutor';
 export * from './filter/N3FilterExecutor';
 export * from './filter/SparqlFilterExecutor';
@@ -27,8 +32,11 @@ export * from './selector/GlobSelectorParser';
 export * from './selector/SelectorHandler';
 export * from './selector/SelectorParser';
 
+export * from './util/CacheUtil';
+
+export * from './BaseDerivationManager';
+export * from './CachedResourceStore';
 export * from './DerivationConfig';
 export * from './DerivationManager';
 export * from './DerivedResourceStore';
-export * from './BaseDerivationManager';
 export * from './Vocabularies';

--- a/src/util/CacheUtil.ts
+++ b/src/util/CacheUtil.ts
@@ -1,0 +1,100 @@
+import {
+  BasicRepresentation,
+  guardedStreamFrom,
+  InternalServerError,
+  pipeSafely,
+  Representation,
+  RepresentationMetadata
+} from '@solid/community-server';
+import { PassThrough, Readable } from 'node:stream';
+
+/**
+ * The cached version of a representation.
+ */
+export interface CachedRepresentation {
+  /**
+   * The data of the representation.
+   * In case the stream was in object mode the value will be an array, otherwise a buffer.
+   */
+  data: Buffer | unknown[];
+  metadata: RepresentationMetadata;
+}
+
+/**
+ * Function that can be used as `sizeCalculation` for an LRU cache storing {@link CachedRepresentation}s.
+ * The length of the data is used, so in the case of an array, the size of the entries is not taken into account.
+ *
+ * @param cached - The cached entry to determine the size of.
+ */
+export function calculateCachedRepresentationSize<T extends CachedRepresentation>(cached: T): number {
+  // Needs to be a positive integer
+  return cached.data.length + 1;
+}
+
+/**
+ * Reads a data stream into an array or buffer, depending on if it is in object mode or not.
+ *
+ * @param stream - Data stream to read.
+ */
+export async function readStream(stream: Readable): Promise<Buffer | unknown[]> {
+  if (stream.readableObjectMode) {
+    const data: unknown[] = [];
+    for await (const obj of stream) {
+      data.push(obj);
+    }
+    return data;
+  }
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    if (typeof chunk === 'string') {
+      chunks.push(Buffer.from(chunk));
+    } else if (Buffer.isBuffer(chunk)) {
+      chunks.push(chunk);
+    } else {
+      throw new InternalServerError(`Streams that are not in object mode should output Buffers or strings, received ${typeof chunk}`);
+    }
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Generates a {@link Representation} based on a {@link CachedRepresentation}.
+ * The generated value is not linked to the {@link CachedRepresentation},
+ * so any changes to it will not impact the original.
+ *
+ * @param cached - {@link CachedRepresentation} to create a representation from
+ */
+export function cachedToRepresentation(cached: CachedRepresentation): Representation {
+  // Copy the metadata quads to prevent changes to the original cached metadata
+  const metadata = new RepresentationMetadata(cached.metadata);
+  return new BasicRepresentation(guardedStreamFrom(cached.data, { objectMode: Array.isArray(cached.data) }), metadata);
+}
+
+/**
+ * Generates a {@link CachedRepresentation} based on a {@link Representation}.
+ * The generated value is not linked to the {@link Representation},
+ * so any changes to it will not impact the original.
+ *
+ * @param representation - Representation to convert.
+ */
+export async function representationToCached(representation: Representation): Promise<CachedRepresentation> {
+  const data = await readStream(representation.data);
+  const metadata = new RepresentationMetadata(representation.metadata);
+  return { data, metadata };
+}
+
+/**
+ * Generates 2 {@link Representation}s from a single one.
+ * After this the input representation should not be used any more.
+ *
+ * @param representation - Representation do duplicate.
+ */
+export function duplicateRepresentation(representation: Representation): [ Representation, Representation ] {
+  const stream1 = pipeSafely(representation.data, new PassThrough({ objectMode: representation.data.readableObjectMode }));
+  const stream2 = pipeSafely(representation.data, new PassThrough({ objectMode: representation.data.readableObjectMode }));
+  return [
+    new BasicRepresentation(stream1, new RepresentationMetadata(representation.metadata)),
+    new BasicRepresentation(stream2, new RepresentationMetadata(representation.metadata)),
+  ];
+}

--- a/test/unit/CachedResourceStore.test.ts
+++ b/test/unit/CachedResourceStore.test.ts
@@ -1,0 +1,144 @@
+import {
+  BasicRepresentation,
+  readableToString,
+  Representation,
+  RepresentationMetadata,
+  ResourceStore
+} from '@solid/community-server';
+import { AuxiliaryIdentifierStrategy } from '@solid/community-server/dist/http/auxiliary/AuxiliaryIdentifierStrategy';
+import { IdentifierMap } from '@solid/community-server/dist/util/map/IdentifierMap';
+import { CachedResourceStore } from '../../src/CachedResourceStore';
+
+async function flushPromises(): Promise<void> {
+  // This flushes the promises, causing the cache to be filled
+  await new Promise(jest.requireActual('timers').setImmediate);
+}
+
+describe('A CachedResourceStore', (): void => {
+  const identifier = { path: 'https://example.com/foo' };
+  const metaIdentifier = { path: 'https://example.com/foo.meta' };
+  let representation: Representation;
+  let source: jest.Mocked<ResourceStore>;
+  let metadataStrategy: jest.Mocked<AuxiliaryIdentifierStrategy>;
+  let store: CachedResourceStore;
+
+  beforeEach(async(): Promise<void> => {
+    representation = new BasicRepresentation('pear', identifier, 'text/turtle');
+    source = {
+      hasResource: jest.fn().mockResolvedValue(true),
+      getRepresentation: jest.fn(async(...args) =>
+        new BasicRepresentation('pear', identifier, 'text/turtle')),
+      addResource: jest.fn(async(id, rep) => new IdentifierMap([[ id, new RepresentationMetadata() ]])),
+      setRepresentation: jest.fn(async(id, rep) => new IdentifierMap([[ id, new RepresentationMetadata() ]])),
+      modifyResource: jest.fn(async(id, rep) => new IdentifierMap([[ id, new RepresentationMetadata() ]])),
+      deleteResource: jest.fn(async(id) => new IdentifierMap([[ id, new RepresentationMetadata() ]])),
+    }
+
+    metadataStrategy = {
+      isAuxiliaryIdentifier: jest.fn((id => id.path.endsWith('.meta'))),
+      getSubjectIdentifier: jest.fn((id => ({ path: id.path.slice(0, -'.meta'.length) }))),
+      getAuxiliaryIdentifier: jest.fn((id => ({ path: id.path + '.meta'}))),
+      getAuxiliaryIdentifiers: jest.fn(),
+    };
+
+    store = new CachedResourceStore({ source, metadataStrategy });
+  });
+
+  it('returns a copy of the source representation if nothing was cached.', async(): Promise<void> => {
+    // The returned stream will not be the same object as it is copied during caching
+    const result = await store.getRepresentation(identifier, {});
+    expect(result.metadata.contentType).toBe('text/turtle');
+    await expect(readableToString(result.data)).resolves.toBe('pear');
+    expect(source.getRepresentation).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a cached copy on subsequent requests.', async(): Promise<void> => {
+    await store.getRepresentation(identifier, {});
+    expect(source.getRepresentation).toHaveBeenCalledTimes(1);
+
+    await flushPromises();
+
+    // Even though we change the source response, we still get the original as it comes from the cache
+    source.getRepresentation.mockResolvedValue(new BasicRepresentation('apple', identifier, 'text/plain'));
+    const result = await store.getRepresentation(identifier, {});
+    expect(result.metadata.contentType).toBe('text/turtle');
+    await expect(readableToString(result.data)).resolves.toBe('pear');
+    expect(source.getRepresentation).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks the source for existence if the identifier is not cached.', async(): Promise<void> => {
+    await expect(store.hasResource(identifier)).resolves.toBe(true);
+    expect(source.hasResource).toHaveBeenCalledTimes(1);
+    expect(source.hasResource).toHaveBeenLastCalledWith(identifier);
+
+    source.hasResource.mockResolvedValueOnce(false);
+    await expect(store.hasResource(identifier)).resolves.toBe(false);
+  });
+
+  it('knows the resource exists if it is in the cache.', async(): Promise<void> => {
+    await store.getRepresentation(identifier, {});
+
+    await flushPromises();
+
+    await expect(store.hasResource(identifier)).resolves.toBe(true);
+    expect(source.hasResource).toHaveBeenCalledTimes(0);
+  });
+
+  it('invalidates the cache when any of the other functions are successful.', async(): Promise<void> => {
+    const calls = [
+      () => store.addResource(identifier, representation),
+      () => store.setRepresentation(identifier, representation),
+      () => store.modifyResource(identifier, representation),
+      () => store.deleteResource(identifier),
+    ];
+    for (const call of calls) {
+      source.getRepresentation.mockClear();
+
+      // Reset cache
+      store = new CachedResourceStore({ source, metadataStrategy });
+
+      // Put in cache
+      await store.getRepresentation(identifier, {});
+      expect(source.getRepresentation).toHaveBeenCalledTimes(1);
+
+      const changeMap = await call();
+      expect([ ...changeMap.keys() ]).toEqual([ identifier ]);
+
+      // Should not be in cache due to call above
+      await store.getRepresentation(identifier, {});
+      expect(source.getRepresentation).toHaveBeenCalledTimes(2);
+    }
+  });
+
+  it('invalidates metadata identifiers when changing a resource.', async(): Promise<void> => {
+    await store.getRepresentation(metaIdentifier, {});
+    await flushPromises();
+    await store.getRepresentation(metaIdentifier, {});
+    expect(source.getRepresentation).toHaveBeenCalledTimes(1);
+
+    await store.setRepresentation(identifier, representation);
+    await flushPromises();
+    await store.getRepresentation(metaIdentifier, {});
+    expect(source.getRepresentation).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates identifiers when changing their metadata.', async(): Promise<void> => {
+    await store.getRepresentation(identifier, {});
+    await flushPromises();
+    await store.getRepresentation(identifier, {});
+    expect(source.getRepresentation).toHaveBeenCalledTimes(1);
+
+    await store.setRepresentation(metaIdentifier, representation);
+    await flushPromises();
+    await store.getRepresentation(identifier, {});
+    expect(source.getRepresentation).toHaveBeenCalledTimes(2);
+  });
+
+  it('can invalidate a caching that is not finished yet.', async(): Promise<void> => {
+    await store.getRepresentation(identifier, {});
+    await store.setRepresentation(identifier, representation);
+    await flushPromises();
+    await store.getRepresentation(identifier, {});
+    expect(source.getRepresentation).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/unit/filter/CachedFilterExecutor.test.ts
+++ b/test/unit/filter/CachedFilterExecutor.test.ts
@@ -1,0 +1,84 @@
+import { BasicRepresentation, DC, readableToString, RepresentationMetadata } from '@solid/community-server';
+import { CachedFilterExecutor } from '../../../src/filter/CachedFilterExecutor';
+import { FilterExecutor, FilterExecutorInput } from '../../../src/filter/FilterExecutor';
+
+async function flushPromises(): Promise<void> {
+  // This flushes the promises, causing the cache to be filled
+  await new Promise(jest.requireActual('timers').setImmediate);
+}
+
+describe('A CachedFilterExecutor', (): void => {
+  const date = new Date();
+  let input: FilterExecutorInput;
+  let source: jest.Mocked<FilterExecutor>;
+  let executor: CachedFilterExecutor;
+
+  beforeEach(async(): Promise<void> => {
+    input = {
+      filter: {
+        data: 'filter data',
+        metadata: new RepresentationMetadata(),
+      },
+      config: {
+        identifier: { path: 'https://example.com' },
+        mappings: { var: 'value', other: 'unused' },
+        selectors: [ 'selector' ],
+        filter: 'filter id',
+        metadata: new RepresentationMetadata(),
+      },
+      representations: [
+        new BasicRepresentation('', new RepresentationMetadata({ [DC.modified]: date.toISOString() })),
+        new BasicRepresentation('', new RepresentationMetadata({ [DC.modified]: date.toISOString() })),
+      ],
+    };
+
+    source = {
+      canHandle: jest.fn(),
+      handle: jest.fn(async(...args) => new BasicRepresentation('test', 'text/plain')),
+    } satisfies Partial<FilterExecutor> as any;
+
+    executor = new CachedFilterExecutor(source);
+  });
+
+  it('can handle anything its source can handle.', async(): Promise<void> => {
+    await expect(executor.canHandle(input)).resolves.toBeUndefined();
+    expect(source.canHandle).toHaveBeenLastCalledWith(input);
+
+    const error = new Error('bad data');
+    source.canHandle.mockRejectedValue(error);
+    await expect(executor.canHandle(input)).rejects.toThrow(error);
+  });
+
+  it('returns the result of the source.', async(): Promise<void> => {
+    const result = await executor.handle(input);
+    await expect(readableToString(result.data)).resolves.toBe('test');
+    expect(result.metadata.contentType).toBe('text/plain');
+    expect(source.handle).toHaveBeenLastCalledWith(input);
+  });
+
+  it('caches the result.', async(): Promise<void> => {
+    await executor.handle(input);
+    expect(source.handle).toHaveBeenCalledTimes(1);
+
+    await flushPromises();
+
+    const result = await executor.handle(input);
+    await expect(readableToString(result.data)).resolves.toBe('test');
+    expect(result.metadata.contentType).toBe('text/plain');
+    expect(source.handle).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not use the cached result if an input changed.', async(): Promise<void> => {
+    await executor.handle(input);
+    expect(source.handle).toHaveBeenCalledTimes(1);
+
+    await flushPromises();
+
+    input.representations[0].metadata.set(DC.terms.modified, new Date().toISOString());
+
+    const result = await executor.handle(input);
+    await expect(readableToString(result.data)).resolves.toBe('test');
+    expect(result.metadata.contentType).toBe('text/plain');
+    expect(source.handle).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/unit/filter/index/BaseQuadFilterParser.test.ts
+++ b/test/unit/filter/index/BaseQuadFilterParser.test.ts
@@ -1,0 +1,32 @@
+import { Quad } from '@rdfjs/types';
+import { BasicRepresentation, INTERNAL_QUADS, readableToQuads } from '@solid/community-server';
+import { DataFactory } from 'n3';
+import { BaseQuadFilterParser } from '../../../../src/filter/idx/BaseQuadFilterParser';
+
+describe('A BaseQuadFilterParser', (): void => {
+  let filter: Partial<Quad> = {
+    predicate: DataFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+    object: DataFactory.variable('v'),
+  };
+  const subject = DataFactory.namedNode('subject');
+  const typeNode = DataFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+  const otherNode = DataFactory.namedNode('http://xmlns.com/foaf/0.1/topic');
+  const type1 = DataFactory.namedNode('http://xmlns.com/foaf/0.1/Agent');
+  const type2 = DataFactory.namedNode('http://xmlns.com/foaf/0.1/Person');
+  const quads = [
+    DataFactory.quad(subject, typeNode, type1),
+    DataFactory.quad(subject, typeNode, type2),
+    DataFactory.quad(subject, otherNode, type1),
+  ];
+  const parser = new BaseQuadFilterParser();
+
+  it('filters matching quads from the stream.', async(): Promise<void> => {
+    const representation = new BasicRepresentation(quads, INTERNAL_QUADS);
+    const result = await parser.handle({ filter, representation });
+    expect(result.readableObjectMode).toBe(true);
+    const store = await readableToQuads(result);
+    expect(store.countQuads(null, null, null, null)).toBe(2);
+    expect(store.countQuads(subject, typeNode, type1, null)).toBe(1);
+    expect(store.countQuads(subject, typeNode, type2, null)).toBe(1);
+  });
+});

--- a/test/unit/filter/index/CachedQuadFilterParser.test.ts
+++ b/test/unit/filter/index/CachedQuadFilterParser.test.ts
@@ -1,0 +1,89 @@
+import { Quad } from '@rdfjs/types';
+import { BasicRepresentation, DC, guardedStreamFrom, readableToQuads, Representation } from '@solid/community-server';
+import { DataFactory } from 'n3';
+import { CachedQuadFilterParser } from '../../../../src/filter/idx/CachedQuadFilterParser';
+import { QuadFilterParser } from '../../../../src/filter/idx/QuadFilterParser';
+
+async function flushPromises(): Promise<void> {
+  // This flushes the promises, causing the cache to be filled
+  await new Promise(jest.requireActual('timers').setImmediate);
+}
+
+describe('A CachedQuadFilterParser', (): void => {
+  let filter: Partial<Quad> = {
+    predicate: DataFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+    object: DataFactory.variable('v'),
+  };
+  const subject = DataFactory.namedNode('subject');
+  const typeNode = DataFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+  const quads = [
+    DataFactory.quad(subject, typeNode, DataFactory.namedNode('http://xmlns.com/foaf/0.1/Agent')),
+    DataFactory.quad(subject, typeNode, DataFactory.namedNode('http://xmlns.com/foaf/0.1/Person')),
+  ];
+  let representation: Representation;
+  let source: jest.Mocked<QuadFilterParser>;
+  let parser: CachedQuadFilterParser;
+
+  beforeEach(async(): Promise<void> => {
+    representation = new BasicRepresentation();
+    representation.metadata.set(DC.terms.modified, new Date(1988, 2, 9).toISOString());
+
+    source = {
+      canHandle: jest.fn(),
+      handle: jest.fn(async() => guardedStreamFrom(quads)),
+    } satisfies Partial<QuadFilterParser> as any;
+
+    parser = new CachedQuadFilterParser(source);
+  });
+
+  it('can handle input its source can handle.', async(): Promise<void> => {
+    await expect(parser.canHandle({ filter, representation })).resolves.toBeUndefined();
+    expect(source.canHandle).toHaveBeenLastCalledWith({ filter, representation });
+
+    const error = new Error('bad data');
+    source.canHandle.mockRejectedValueOnce(error);
+    await expect(parser.canHandle({ filter, representation })).rejects.toThrow(error);
+  });
+
+  it('caches results after the first call.', async(): Promise<void> => {
+    let result = await parser.handle({ filter, representation });
+    let store = await readableToQuads(result);
+    expect(store.countQuads(null, null, null, null)).toBe(2);
+    expect(source.handle).toHaveBeenCalledTimes(1);
+    expect(source.handle).toHaveBeenLastCalledWith({ filter, representation });
+
+    result = await parser.handle({ filter, representation });
+    store = await readableToQuads(result);
+    expect(store.countQuads(null, null, null, null)).toBe(2);
+    // Count did not change
+    expect(source.handle).toHaveBeenCalledTimes(1);
+
+    representation.metadata.set(DC.terms.modified, new Date().toISOString());
+    result = await parser.handle({ filter, representation });
+    store = await readableToQuads(result);
+    expect(store.countQuads(null, null, null, null)).toBe(2);
+    // Count changed
+    expect(source.handle).toHaveBeenCalledTimes(2);
+  });
+
+  it('has different cache entries per quad filter.', async(): Promise<void> => {
+    let filter2: Partial<Quad> = { predicate: DataFactory.variable('v') };
+    await parser.handle({ filter, representation });
+    await parser.handle({ filter: filter2, representation });
+    expect(source.handle).toHaveBeenCalledTimes(2);
+
+    await flushPromises();
+
+    // Both of these should be cached so no extra calls
+    await parser.handle({ filter, representation });
+    await parser.handle({ filter: filter2, representation });
+    expect(source.handle).toHaveBeenCalledTimes(2);
+
+    // Only the resource that is changed should be invalidated, the other one should still be cached
+    const representation2 = new BasicRepresentation();
+    representation2.metadata.set(DC.terms.modified, new Date().toISOString());
+    await parser.handle({ filter, representation });
+    await parser.handle({ filter: filter2, representation: representation2 });
+    expect(source.handle).toHaveBeenCalledTimes(3);
+  });
+});

--- a/test/unit/util/CacheUtil.test.ts
+++ b/test/unit/util/CacheUtil.test.ts
@@ -1,0 +1,74 @@
+import { BasicRepresentation, CONTENT_TYPE, readableToString, RepresentationMetadata } from '@solid/community-server';
+import { LRUCache } from 'lru-cache';
+import { Readable } from 'node:stream';
+import {
+  CachedRepresentation, representationToCached,
+  calculateCachedRepresentationSize,
+  cachedToRepresentation,
+  readStream, duplicateRepresentation
+} from '../../../src/util/CacheUtil';
+
+describe('CacheUtil', (): void => {
+  describe('#calculateCachedRepresentationSize', (): void => {
+    it('returns the length of the data + 1.', async(): Promise<void> => {
+      expect(calculateCachedRepresentationSize({ data: [ 1, 2 ], metadata: new RepresentationMetadata() })).toBe(3);
+    });
+  });
+
+  describe('#readStream', (): void => {
+    it('converts object streams to arrays.', async(): Promise<void> => {
+      await expect(readStream(Readable.from([ 1, 2, 3 ]))).resolves.toEqual([ 1, 2, 3]);
+    });
+
+    it('reads streams into a Buffer.', async(): Promise<void> => {
+      await expect(readStream(Readable.from('pear', { objectMode: false })))
+        .resolves.toEqual(Buffer.from('pear'));
+    });
+  });
+
+  describe('#cachedToRepresentation', (): void => {
+    it('returns a representation containing a copy of the stored data.', async(): Promise<void> => {
+      const data = Buffer.from('pear');
+      const metadata = new RepresentationMetadata({ [CONTENT_TYPE]: 'text/plain' });
+      const result = cachedToRepresentation({ data, metadata });
+      expect(result.metadata.contentType).toBe('text/plain');
+      await expect(readableToString(result.data)).resolves.toBe('pear');
+      result.metadata.contentType = 'text/turtle';
+      // Did not change the original metadata
+      expect(metadata.contentType).toBe('text/plain');
+    });
+  });
+
+  describe('#representationToCached', (): void => {
+    it('caches a representation and returns a copy that can still be used.', async(): Promise<void> => {
+      const representation = new BasicRepresentation('pear', 'text/plain');
+      const cached = await representationToCached(representation);
+
+      expect(cached.data).toEqual([ 'pear' ]);
+      expect(cached.metadata.contentType).toBe('text/plain');
+
+      // Changing content type to make sure original version doesn't change
+      cached.metadata.contentType = 'text/turtle';
+      expect(representation.metadata.contentType).toBe('text/plain');
+    });
+  });
+
+  describe('#duplicateRepresentation', (): void => {
+    it('duplicates a representation.', async(): Promise<void> => {
+      const representation = new BasicRepresentation('test', 'text/plain');
+      const [ copy1, copy2 ] = duplicateRepresentation(representation);
+      await expect(readableToString(copy1.data)).resolves.toBe('test');
+      await expect(readableToString(copy2.data)).resolves.toBe('test');
+      expect(copy1.metadata.contentType).toBe('text/plain');
+      expect(copy2.metadata.contentType).toBe('text/plain');
+
+      // Make sure these are distinct metadata objects
+      copy1.metadata.contentType = 'text/turtle';
+      copy2.metadata.contentType = 'text/n3';
+
+      expect(representation.metadata.contentType).toBe('text/plain');
+      expect(copy1.metadata.contentType).toBe('text/turtle');
+      expect(copy2.metadata.contentType).toBe('text/n3');
+    });
+  });
+});


### PR DESCRIPTION
Adds caching to prevent having to do expensive work multiple times.

There are three places where caching is added:
* For accessing resources from the backend. This can help if there are a lot of sources that need to be read to derive a single resource. This is independent of derived resources so could be added to the main CSS repo.
* For storing derived resource representations. So these do not have to be generated multiple times. The values will be invalidated if any of the input resources change, or if the filter changes.
* For storing index results of a single resource for a filter. As derived index resources will often have changing inputs, due do different credentials being used, this helps storing the parts that do not change. Similar to the previous step, if the input resource is modified the cache entry will be invalidated.

In all cases an LRU cache is used whose size can be configured.

See the documentation for more details.