### PR TITLE
Add support for derived resources based on SHACL resources

### DIFF
--- a/config/parts/filter.json
+++ b/config/parts/filter.json
@@ -20,7 +20,11 @@
         "@id": "urn:solid-server:default:MappingFilterParser",
         "@type": "MappingFilterParser",
         "source": {
-          "@type": "InputFilterParser"
+          "@type": "WaterfallHandler",
+          "handlers": [
+            { "@type": "QuadFilterParser" },
+            { "@type": "InputFilterParser" }
+          ]
         }
       }
     },
@@ -45,7 +49,11 @@
             "@id": "urn:solid-server:default:StoreDataFilterExecutor",
             "@type": "StoreDataFilterExecutor",
             "source": {
-              "@type": "SparqlFilterExecutor"
+              "@type": "WaterfallHandler",
+              "handlers": [
+                { "@type": "SparqlFilterExecutor" },
+                { "@type": "ShaclFilterExecutor" }
+              ]
             }
           }
         ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "lru-cache": "^10.4.3",
         "n3": "^1.17.4",
         "rdf-string": "^1.6.3",
+        "rdf-validate-shacl": "^0.4.5",
         "uri-template-lite": "^23.4.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lru-cache": "^10.4.3",
     "n3": "^1.17.4",
     "rdf-string": "^1.6.3",
+    "rdf-validate-shacl": "^0.4.5",
     "uri-template-lite": "^23.4.0"
   },
   "devDependencies": {

--- a/src/Vocabularies.ts
+++ b/src/Vocabularies.ts
@@ -18,3 +18,19 @@ export const DERIVED_INDEX = createVocabulary(
   'for',
   'instance',
 );
+
+export const SH = createVocabulary(
+  'http://www.w3.org/ns/shacl#',
+  'property',
+  'path',
+  'node',
+
+  // Validation report
+  'focusNode',
+
+  // Focus node
+  'targetNode',
+  'targetClass',
+  'targetSubjectsOf',
+  'targetObjectsOf',
+);

--- a/src/filter/N3FilterExecutor.ts
+++ b/src/filter/N3FilterExecutor.ts
@@ -22,4 +22,4 @@ export interface N3FilterExecutorInput<T = unknown> {
 /**
  * Similar to a {@link FilterExecutor} but takes an N3.js store as input instead.
  */
-export abstract class N3FilterExecutor extends AsyncHandler<N3FilterExecutorInput, Representation> {}
+export abstract class N3FilterExecutor<T = unknown> extends AsyncHandler<N3FilterExecutorInput<T>, Representation> {}

--- a/src/filter/QuadFilterParser.ts
+++ b/src/filter/QuadFilterParser.ts
@@ -1,0 +1,40 @@
+import {
+  createErrorMessage,
+  getLoggerFor,
+  InternalServerError,
+  NotImplementedHttpError,
+  RepresentationMetadata,
+} from '@solid/community-server';
+import { Parser, Store } from 'n3';
+import type { DerivationConfig } from '../DerivationConfig';
+import type { Filter } from './Filter';
+import { FilterParser } from './FilterParser';
+
+// TODO:
+export class QuadFilterParser extends FilterParser<Store> {
+  protected readonly logger = getLoggerFor(this);
+
+  protected readonly cache = new WeakMap<DerivationConfig, Store>();
+
+  public async canHandle(input: DerivationConfig): Promise<void> {
+    const parser = new Parser();
+    try {
+      const quads = parser.parse(input.filter);
+      this.cache.set(input, new Store(quads));
+    } catch (error: unknown) {
+      this.logger.debug(`Unable to parse filter to quads: ${createErrorMessage(error)}`);
+      throw new NotImplementedHttpError('Only valid turtle input is accepted');
+    }
+  }
+
+  public async handle(input: DerivationConfig): Promise<Filter<Store>> {
+    const store = this.cache.get(input);
+    if (!store) {
+      throw new InternalServerError('Calling handle before calling canHandle');
+    }
+    return {
+      data: store,
+      metadata: new RepresentationMetadata(),
+    };
+  }
+}

--- a/src/filter/ShaclFilterExecutor.ts
+++ b/src/filter/ShaclFilterExecutor.ts
@@ -1,0 +1,119 @@
+import { Readable } from 'node:stream';
+import type { Quad, Term } from '@rdfjs/types';
+import type { Representation } from '@solid/community-server';
+import {
+  BasicRepresentation,
+  getLoggerFor,
+  INTERNAL_QUADS,
+  NotImplementedHttpError,
+  RDF,
+} from '@solid/community-server';
+import type { Store } from 'n3';
+import SHACLValidator from 'rdf-validate-shacl';
+import { SH } from '../Vocabularies';
+import type { N3FilterExecutorInput } from './N3FilterExecutor';
+import { N3FilterExecutor } from './N3FilterExecutor';
+
+export interface PredicatePath extends Record<string, PredicatePath> {}
+
+export class ShaclFilterExecutor extends N3FilterExecutor<Store> {
+  protected readonly logger = getLoggerFor(this);
+
+  public async canHandle(input: N3FilterExecutorInput<Store>): Promise<void> {
+    if (typeof input.filter.data !== 'object' || !('countQuads' in input.filter.data)) {
+      throw new NotImplementedHttpError('Expected an N3.js Store as filter');
+    }
+    if (input.filter.data.countQuads(null, SH.terms.property, null, null) === 0) {
+      throw new NotImplementedHttpError('Expected at least one sh:property predicate in a SHACL resource');
+    }
+  }
+
+  public async handle(input: N3FilterExecutorInput<Store>): Promise<Representation> {
+    return new BasicRepresentation(
+      Readable.from(this.extractMatchingTriples(input.data, input.filter.data)),
+      input.config.identifier,
+      INTERNAL_QUADS,
+    );
+  }
+
+  protected* extractMatchingTriples(data: Store, shapes: Store): IterableIterator<Quad> {
+    const validator = new SHACLValidator(shapes);
+    const report = validator.validate(data);
+
+    const paths: Record<string, PredicatePath> = {};
+    for (const { focusNode, shapeNode } of this.findFocusNodes(data, shapes)) {
+      if (report.dataset.match(null, SH.terms.focusNode, focusNode).size > 0) {
+        continue;
+      }
+      const path = paths[shapeNode.value] ?? this.findValidPath(shapes, shapeNode);
+      paths[shapeNode.value] = path;
+      yield* this.extractValidTriples(data, path, focusNode);
+    }
+  }
+
+  protected* findFocusNodes(data: Store, shapes: Store): IterableIterator<{ focusNode: Term; shapeNode: Term }> {
+    for (const { subject: shapeNode, object: focusNode } of shapes.getQuads(null, SH.terms.targetNode, null, null)) {
+      yield { focusNode, shapeNode };
+    }
+
+    for (const { subject: shapeNode, object: classNode } of shapes.getQuads(null, SH.terms.targetClass, null, null)) {
+      for (const focusNode of data.getSubjects(RDF.terms.type, classNode, null)) {
+        yield { focusNode, shapeNode };
+      }
+    }
+
+    for (const { subject: shapeNode, object: pred } of shapes.getQuads(null, SH.terms.targetSubjectsOf, null, null)) {
+      for (const focusNode of data.getSubjects(pred, null, null)) {
+        yield { focusNode, shapeNode };
+      }
+    }
+
+    for (const { subject: shapeNode, object: pred } of shapes.getQuads(null, SH.terms.targetObjectsOf, null, null)) {
+      for (const focusNode of data.getObjects(null, pred, null)) {
+        yield { focusNode, shapeNode };
+      }
+    }
+  }
+
+  protected findValidPath(shapes: Store, shapeNode: Term): PredicatePath {
+    const result: PredicatePath = {};
+
+    const properties = shapes.getObjects(shapeNode, SH.terms.property, null);
+    for (const property of properties) {
+      const pathObjects = shapes.getObjects(property, SH.terms.path, null);
+      if (pathObjects.length !== 1) {
+        this.logger.warn(`Skipping property with not exactly 1 sh:path node.`);
+        continue;
+      }
+      const predicate = pathObjects[0];
+      result[predicate.value] = result[predicate.value] ?? {};
+
+      for (const node of shapes.getObjects(property, SH.terms.node, null)) {
+        result[predicate.value] = this.mergePaths(result[predicate.value], this.findValidPath(shapes, node));
+      }
+    }
+
+    return result;
+  }
+
+  protected mergePaths(pathA: PredicatePath, pathB: PredicatePath): PredicatePath {
+    const result = { ...pathA };
+    for (const key of Object.keys(pathB)) {
+      if (result[key]) {
+        result[key] = this.mergePaths(pathA[key], pathB[key]);
+      } else {
+        result[key] = pathB[key];
+      }
+    }
+    return result;
+  }
+
+  protected* extractValidTriples(data: Store, path: PredicatePath, focusNode: Term): IterableIterator<Quad> {
+    for (const [ key, childPath ] of Object.entries(path)) {
+      for (const quad of data.getQuads(focusNode, key, null, null)) {
+        yield quad;
+        yield* this.extractValidTriples(data, childPath, quad.object);
+      }
+    }
+  }
+}

--- a/src/filter/SparqlFilterExecutor.ts
+++ b/src/filter/SparqlFilterExecutor.ts
@@ -20,7 +20,7 @@ import { N3FilterExecutor } from './N3FilterExecutor';
 /**
  * Applies a SPARQL filter to an N3.js store.
  */
-export class SparqlFilterExecutor extends N3FilterExecutor {
+export class SparqlFilterExecutor extends N3FilterExecutor<string> {
   protected readonly logger = getLoggerFor(this);
   protected readonly engine: QueryEngine;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,9 @@ export * from './filter/FilterParser';
 export * from './filter/InputFilterParser';
 export * from './filter/MappingFilterParser';
 export * from './filter/N3FilterExecutor';
+export * from './filter/QuadFilterParser';
 export * from './filter/ResourceFilterParser';
+export * from './filter/ShaclFilterExecutor';
 export * from './filter/SparqlFilterExecutor';
 export * from './filter/StoreDataFilterExecutor';
 

--- a/templates/root/base/derived/.meta
+++ b/templates/root/base/derived/.meta
@@ -48,3 +48,10 @@
         derived:selector <../data/container/data1>, <../data/container/data2>;
         derived:filter <../filters/name>
     ].
+
+<>
+    derived:derivedResource [
+        derived:template "shacl";
+        derived:selector <../data/container/*>;
+        derived:filter <../filters/shacl>
+    ].

--- a/templates/root/base/filters/shacl$.ttl
+++ b/templates/root/base/filters/shacl$.ttl
@@ -1,0 +1,13 @@
+@prefix ex: <http://example.com/ns#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+ex:Shape
+  a sh:NodeShape ;
+  sh:targetSubjectsOf foaf:knows ;
+  sh:property [
+    sh:path foaf:name ;
+    sh:hasValue "Example"
+  ] .

--- a/test/integration/Example.test.ts
+++ b/test/integration/Example.test.ts
@@ -53,7 +53,7 @@ describe('The server test setup', (): void => {
   it('returns the contents of the derived root container.', async(): Promise<void> => {
     const res = await fetch('http://localhost:3456/derived/');
     const store = await responseToStore(res, 'http://localhost:3456/derived/');
-    expect(store.countQuads(null, null, null, null)).toBe(5);
+    expect(store.countQuads(null, null, null, null)).toBe(6);
     const subject = namedNode('http://localhost:3456/derived/');
     const contains = namedNode('http://www.w3.org/ns/ldp#contains');
     expect(store.countQuads(subject, contains, namedNode('http://localhost:3456/derived/test'), null)).toBe(1);
@@ -61,6 +61,7 @@ describe('The server test setup', (): void => {
     expect(store.countQuads(subject, contains, namedNode('http://localhost:3456/derived/query%7B?var%7D'), null)).toBe(1);
     expect(store.countQuads(subject, contains, namedNode('http://localhost:3456/derived/pattern'), null)).toBe(1);
     expect(store.countQuads(subject, contains, namedNode('http://localhost:3456/derived/multiple'), null)).toBe(1);
+    expect(store.countQuads(subject, contains, namedNode('http://localhost:3456/derived/shacl'), null)).toBe(1);
   });
 
   it('still returns original resources.', async(): Promise<void> => {

--- a/test/unit/filter/QuadFilterParser.test.ts
+++ b/test/unit/filter/QuadFilterParser.test.ts
@@ -1,0 +1,33 @@
+import { InternalServerError, NotImplementedHttpError, RepresentationMetadata } from '@solid/community-server';
+import type { DerivationConfig } from '../../../src/DerivationConfig';
+import { QuadFilterParser } from '../../../src/filter/QuadFilterParser';
+
+describe('QuadFilterParser', (): void => {
+  let config: DerivationConfig;
+  const parser = new QuadFilterParser();
+
+  beforeEach(async(): Promise<void> => {
+    config = {
+      identifier: { path: 'path' },
+      filter: '<a> <b> <c>.',
+      mappings: {},
+      selectors: [],
+      metadata: new RepresentationMetadata(),
+    };
+  });
+
+  it('parses the filter into quads.', async(): Promise<void> => {
+    const filter = await parser.handleSafe(config);
+    expect('getQuads' in filter.data).toBe(true);
+    expect(filter.data.size).toBe(1);
+  });
+
+  it('errors for non-turtle input.', async(): Promise<void> => {
+    config.filter = 'not turtle';
+    await expect(parser.canHandle(config)).rejects.toThrow(NotImplementedHttpError);
+  });
+
+  it('errors calling handle before canHandle.', async(): Promise<void> => {
+    await expect(parser.handle(config)).rejects.toThrow(InternalServerError);
+  });
+});

--- a/test/unit/filter/ShaclFilterExecutor.test.ts
+++ b/test/unit/filter/ShaclFilterExecutor.test.ts
@@ -1,0 +1,116 @@
+import {
+  INTERNAL_QUADS,
+  readableToQuads,
+  RepresentationMetadata,
+} from '@solid/community-server';
+import { Parser, Store } from 'n3';
+import type { N3FilterExecutorInput } from '../../../src/filter/N3FilterExecutor';
+import { ShaclFilterExecutor } from '../../../src/filter/ShaclFilterExecutor';
+
+describe('ShaclFilterExecutor', (): void => {
+  const turtle = `
+    @prefix ex: <http://example.com/ns#>.
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+    @prefix sh: <http://www.w3.org/ns/shacl#>.
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+  
+    ex:Alice
+      a ex:Person ;
+      ex:address [ ex:postalCode "1234" ] ;
+      ex:worksFor ex:AliceCompany .
+      
+    ex:Bob
+      a ex:Person ;
+      ex:address [ ex:postalCode "1234" ], [ ex:postalCode "5678" ].
+      
+    ex:Calvin
+      a ex:Person ;
+      ex:birthDate "1971-07-07"^^xsd:date ;
+      ex:worksFor ex:UntypedCompany .
+  `;
+  const shacl = `
+    @prefix ex: <http://example.com/ns#>.
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+    @prefix sh: <http://www.w3.org/ns/shacl#>.
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+  
+    ex:PersonShape
+      a sh:NodeShape ;
+      sh:targetClass ex:Person ;
+      sh:property [
+        sh:path ex:address ;
+        sh:maxCount 1 ;
+        sh:node ex:AddressShape ;
+      ] ;
+      sh:property [
+        sh:path ex:worksFor ;
+        sh:nodeKind sh:IRI ;
+      ] ;
+      sh:closed true ;
+      sh:ignoredProperties ( rdf:type ) .
+    
+    ex:AddressShape
+      a sh:NodeShape ;
+      sh:property [
+        sh:path ex:postalCode ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+      ] .
+  `;
+
+  let input: N3FilterExecutorInput<Store>;
+  const parser = new ShaclFilterExecutor();
+
+  beforeEach(async(): Promise<void> => {
+    input = {
+      config: {
+        identifier: { path: 'path' },
+        mappings: {},
+        selectors: [],
+        filter: 'filter',
+        metadata: new RepresentationMetadata(),
+      },
+      filter: {
+        data: new Store(new Parser().parse(shacl)),
+        metadata: new RepresentationMetadata(),
+      },
+      data: new Store(new Parser().parse(turtle)),
+    };
+  });
+
+  it('can only handle N3.js Store filters.', async(): Promise<void> => {
+    input.filter.data = 'not a store' as any;
+    await expect(parser.canHandle(input)).rejects.toThrow('Expected an N3.js Store as filter');
+  });
+
+  it('can only handle Shacl filters.', async(): Promise<void> => {
+    input.filter.data = new Store();
+    await expect(parser.canHandle(input))
+      .rejects.toThrow('Expected at least one sh:property predicate in a SHACL resource');
+  });
+
+  it('extracts triples matching the shape.', async(): Promise<void> => {
+    const result = await parser.handle(input);
+    expect(result.metadata.contentType).toBe(INTERNAL_QUADS);
+    const store = await readableToQuads(result.data);
+    expect(store.size).toBe(3);
+    expect(store.countQuads(
+      'http://example.com/ns#Alice',
+      'http://example.com/ns#worksFor',
+      'http://example.com/ns#AliceCompany',
+      null,
+    )).toBe(1);
+    const addresses = store.getObjects(
+      'http://example.com/ns#Alice',
+      'http://example.com/ns#address',
+      null,
+    );
+    expect(addresses).toHaveLength(1);
+    expect(store.countQuads(
+      addresses[0],
+      'http://example.com/ns#postalCode',
+      '"1234"',
+      null,
+    )).toBe(1);
+  });
+});


### PR DESCRIPTION
Generates a derived resource using SHACL.

 * Load selected resources in memory
 * Find all focus nodes according to the SHACL resource.
 * Remove the nodes that do not comply.
 * Return all triples described by the SHACL resource for the remaining focus nodes.